### PR TITLE
Integrate OpenAI LLM provider

### DIFF
--- a/configs/openmcp.json
+++ b/configs/openmcp.json
@@ -8,12 +8,19 @@
     }
   },
   "llm": {
-    "provider": "python_bridge",
+    "provider": "openai",
     "python_bridge": {
-      "enabled": true,
+      "enabled": false,
       "python_executable": "python3",
       "script_path": "scripts/llm_bridge.py",
       "working_dir": ".."
+    },
+    "openai": {
+      "enabled": true,
+      "api_key_env": "OPENAI_API_KEY",
+      "base_url": "https://api.openai.com/v1",
+      "model": "gpt-4o-mini",
+      "timeout_seconds": 60
     }
   },
   "agent": {

--- a/configs/openmcp.mysql.json
+++ b/configs/openmcp.mysql.json
@@ -9,12 +9,19 @@
     }
   },
   "llm": {
-    "provider": "python_bridge",
+    "provider": "openai",
     "python_bridge": {
-      "enabled": true,
+      "enabled": false,
       "python_executable": "python3",
       "script_path": "scripts/llm_bridge.py",
       "working_dir": ".."
+    },
+    "openai": {
+      "enabled": true,
+      "api_key_env": "OPENAI_API_KEY",
+      "base_url": "https://api.openai.com/v1",
+      "model": "gpt-4o-mini",
+      "timeout_seconds": 60
     }
   },
   "agent": {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -1,0 +1,56 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"OpenMCP-Chain/internal/llm"
+)
+
+type stubLLM struct {
+	resp *llm.Response
+	err  error
+	wait time.Duration
+}
+
+func (s *stubLLM) Generate(ctx context.Context, req llm.Request) (*llm.Response, error) {
+	if s.wait > 0 {
+		select {
+		case <-time.After(s.wait):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.resp, nil
+}
+
+func TestAgentExecuteSuccess(t *testing.T) {
+	llmClient := &stubLLM{resp: &llm.Response{Thought: "分析", Reply: "结果"}}
+	ag := New(llmClient, nil, nil)
+
+	result, err := ag.Execute(context.Background(), TaskRequest{Goal: "测试"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Reply != "结果" || result.Thought != "分析" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestAgentExecuteTimeout(t *testing.T) {
+	llmClient := &stubLLM{wait: 50 * time.Millisecond}
+	ag := New(llmClient, nil, nil, WithLLMTimeout(10*time.Millisecond))
+
+	_, err := ag.Execute(context.Background(), TaskRequest{Goal: "测试"})
+	if err == nil {
+		t.Fatalf("expected timeout error")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context deadline exceeded, got %v", err)
+	}
+}

--- a/internal/ai/doc.go
+++ b/internal/ai/doc.go
@@ -1,0 +1,11 @@
+// Package ai 汇总了系统中与大模型推理相关的组件说明。
+//
+// 历史上 OpenMCP 通过 scripts/llm_bridge.py 提供的 Python 脚本来模拟大模型，
+// 由 internal/llm/pythonbridge 客户端调用脚本并返回 Thought/Reply 结构。该方案
+// 适用于离线演示，但无法访问真实的大语言模型服务。
+//
+// 为了支持真实的 API 调用，本目录同时记录了接口规范（参见 internal/llm 包中
+// 的 Request/Response 定义）以及外部推理服务（例如 OpenAI）的客户端实现在
+// 哪些包中。新的实现位于 internal/llm/openai，通过 HTTP API 将 Agent 的上下文
+// 转换成对话消息并解析模型的结构化输出。
+package ai

--- a/internal/llm/openai/client.go
+++ b/internal/llm/openai/client.go
@@ -1,0 +1,221 @@
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"OpenMCP-Chain/internal/llm"
+)
+
+const (
+	defaultBaseURL   = "https://api.openai.com/v1"
+	defaultModelName = "gpt-4o-mini"
+	defaultTimeout   = 60 * time.Second
+)
+
+// Config 描述了调用 OpenAI Chat Completions API 所需的信息。
+type Config struct {
+	APIKey  string
+	BaseURL string
+	Model   string
+	Timeout time.Duration
+}
+
+// Client 通过 HTTP 调用 OpenAI 提供的大模型能力。
+type Client struct {
+	apiKey     string
+	baseURL    string
+	model      string
+	httpClient *http.Client
+}
+
+// NewClient 根据配置创建 OpenAI 客户端。
+func NewClient(cfg Config) (*Client, error) {
+	apiKey := strings.TrimSpace(cfg.APIKey)
+	if apiKey == "" {
+		return nil, errors.New("未提供 OpenAI API Key")
+	}
+
+	baseURL := strings.TrimSpace(cfg.BaseURL)
+	if baseURL == "" {
+		baseURL = defaultBaseURL
+	}
+	baseURL = strings.TrimRight(baseURL, "/")
+
+	model := strings.TrimSpace(cfg.Model)
+	if model == "" {
+		model = defaultModelName
+	}
+
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+
+	return &Client{
+		apiKey:  apiKey,
+		baseURL: baseURL,
+		model:   model,
+		httpClient: &http.Client{
+			Timeout: timeout,
+		},
+	}, nil
+}
+
+// Generate 调用 OpenAI 生成结构化回复。
+func (c *Client) Generate(ctx context.Context, req llm.Request) (*llm.Response, error) {
+	payload, err := c.buildPayload(req)
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint := c.baseURL + "/chat/completions"
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("构建 OpenAI 请求失败: %w", err)
+	}
+
+	httpReq.Header.Set("Authorization", "Bearer "+c.apiKey)
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("请求 OpenAI 失败: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, fmt.Errorf("OpenAI 返回错误状态 %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var decoded struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("解析 OpenAI 响应失败: %w", err)
+	}
+	if len(decoded.Choices) == 0 {
+		return nil, errors.New("OpenAI 响应中没有有效的 choices")
+	}
+
+	content := strings.TrimSpace(decoded.Choices[0].Message.Content)
+	if content == "" {
+		return nil, errors.New("OpenAI 响应内容为空")
+	}
+
+	var structured struct {
+		Thought string `json:"thought"`
+		Reply   string `json:"reply"`
+	}
+	if err := json.Unmarshal([]byte(content), &structured); err != nil {
+		structured.Reply = content
+		structured.Thought = ""
+	}
+	if strings.TrimSpace(structured.Reply) == "" {
+		structured.Reply = content
+	}
+
+	return &llm.Response{
+		Thought: structured.Thought,
+		Reply:   structured.Reply,
+	}, nil
+}
+
+func (c *Client) buildPayload(req llm.Request) ([]byte, error) {
+	type message struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+
+	messages := []message{
+		{
+			Role:    "system",
+			Content: systemPrompt,
+		},
+		{
+			Role:    "user",
+			Content: buildUserPrompt(req),
+		},
+	}
+
+	body := map[string]any{
+		"model":       c.model,
+		"messages":    messages,
+		"temperature": 0.2,
+	}
+
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("序列化 OpenAI 请求失败: %w", err)
+	}
+	return encoded, nil
+}
+
+const systemPrompt = "" +
+	"You are OpenMCP's reasoning engine. " +
+	"Always respond with a compact JSON object: {\"thought\": string, \"reply\": string}. " +
+	"Use Chinese for the reply and summarise the reasoning in \"thought\"."
+
+func buildUserPrompt(req llm.Request) string {
+	var builder strings.Builder
+	builder.WriteString("## 当前任务\n")
+	builder.WriteString(fmt.Sprintf("目标: %s\n", strings.TrimSpace(req.Goal)))
+	if action := strings.TrimSpace(req.ChainAction); action != "" {
+		builder.WriteString(fmt.Sprintf("链上操作: %s\n", action))
+	}
+	if address := strings.TrimSpace(req.Address); address != "" {
+		builder.WriteString(fmt.Sprintf("相关地址: %s\n", address))
+	}
+
+	if len(req.History) > 0 {
+		builder.WriteString("\n## 历史上下文\n")
+		for idx, entry := range req.History {
+			builder.WriteString(fmt.Sprintf("[%d] 目标:%s | 反馈:%s | 观察:%s\n",
+				idx+1,
+				strings.TrimSpace(entry.Goal),
+				truncate(entry.Reply),
+				truncate(entry.Observations),
+			))
+			if idx >= 4 {
+				break
+			}
+		}
+	}
+
+	if len(req.Knowledge) > 0 {
+		builder.WriteString("\n## 知识库\n")
+		for idx, card := range req.Knowledge {
+			builder.WriteString(fmt.Sprintf("[%d] %s: %s\n",
+				idx+1,
+				strings.TrimSpace(card.Title),
+				truncate(card.Content),
+			))
+			if idx >= 4 {
+				break
+			}
+		}
+	}
+
+	builder.WriteString("\n请依据上述信息给出最合理的推理 thought，以及供用户执行的 reply。")
+	return builder.String()
+}
+
+func truncate(text string) string {
+	text = strings.TrimSpace(text)
+	if len([]rune(text)) > 80 {
+		return string([]rune(text)[:80]) + "..."
+	}
+	return text
+}

--- a/internal/llm/openai/client_test.go
+++ b/internal/llm/openai/client_test.go
@@ -1,0 +1,85 @@
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"OpenMCP-Chain/internal/llm"
+)
+
+func TestNewClientValidation(t *testing.T) {
+	if _, err := NewClient(Config{}); err == nil {
+		t.Fatalf("expected error when api key is missing")
+	}
+}
+
+func TestGenerateSuccess(t *testing.T) {
+	var captured struct {
+		Authorization string
+		Body          map[string]any
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		captured.Authorization = r.Header.Get("Authorization")
+		defer r.Body.Close()
+		if err := json.NewDecoder(r.Body).Decode(&captured.Body); err != nil {
+			t.Fatalf("failed to decode body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"choices": []map[string]any{
+				{
+					"message": map[string]any{
+						"content": `{"thought":"分析","reply":"你好"}`,
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(Config{APIKey: "test", BaseURL: srv.URL, Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	client.httpClient = srv.Client()
+
+	resp, err := client.Generate(context.Background(), llm.Request{Goal: "测试"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if resp.Reply != "你好" || resp.Thought != "分析" {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+
+	if !strings.HasPrefix(captured.Authorization, "Bearer ") {
+		t.Fatalf("authorization header missing: %q", captured.Authorization)
+	}
+
+	if captured.Body["model"] == "" {
+		t.Fatalf("model field missing in request")
+	}
+}
+
+func TestGenerateHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(Config{APIKey: "test", BaseURL: srv.URL, Timeout: time.Second})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	client.httpClient = srv.Client()
+
+	if _, err := client.Generate(context.Background(), llm.Request{Goal: "test"}); err == nil {
+		t.Fatalf("expected error when http status is not success")
+	}
+}


### PR DESCRIPTION
## Summary
- document the AI integration surface and add an OpenAI chat client with prompt formatting and response parsing tests
- extend configuration and the daemon bootstrap to load OpenAI credentials, instantiate the proper LLM client, and surface a timeout option to the agent
- update the agent with LLM timeout handling and add unit tests alongside sample configs that default to the OpenAI provider

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68f2f9693770832fbbbaeea4ded510b7