### PR TITLE
feat: expand web3 capabilities with multi-chain support

### DIFF
--- a/cmd/openmcpd/main.go
+++ b/cmd/openmcpd/main.go
@@ -19,7 +19,7 @@ import (
 	"OpenMCP-Chain/internal/llm/openai"
 	"OpenMCP-Chain/internal/llm/pythonbridge"
 	"OpenMCP-Chain/internal/storage/mysql"
-	"OpenMCP-Chain/internal/web3/ethereum"
+	"OpenMCP-Chain/internal/web3/provider"
 )
 
 // main 是 OpenMCP 守护进程的入口。
@@ -76,7 +76,16 @@ func run(ctx context.Context) error {
 		defer closer.Close()
 	}
 
-	web3Client := ethereum.NewClient(cfg.Web3.RPCURL)
+	chainRegistry, err := provider.NewRegistry(ctx, cfg.Web3)
+	if err != nil {
+		return err
+	}
+	defer chainRegistry.Close()
+
+	web3Client, err := chainRegistry.DefaultClient()
+	if err != nil {
+		return err
+	}
 
 	var knowledgeProvider knowledge.Provider
 	if cfg.Knowledge.Source != "" {

--- a/configs/chain.yaml
+++ b/configs/chain.yaml
@@ -1,0 +1,14 @@
+chains:
+  local-ethereum:
+    type: evm
+    rpc_url: http://localhost:8545
+    ws_url: ws://localhost:8546
+    description: Local development Ethereum node
+  polygon-mainnet:
+    type: evm
+    rpc_url: https://polygon-rpc.com
+    description: Public Polygon RPC endpoint
+  bsc-mainnet:
+    type: evm
+    rpc_url: https://bsc-dataseed.binance.org
+    description: Public BSC RPC endpoint

--- a/configs/openmcp.json
+++ b/configs/openmcp.json
@@ -31,7 +31,9 @@
     "max_results": 3
   },
   "web3": {
-    "rpc_url": "http://localhost:8545"
+    "rpc_url": "http://localhost:8545",
+    "chain_config": "../configs/chain.yaml",
+    "default_chain": "local-ethereum"
   },
   "runtime": {
     "data_dir": "../data"

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module OpenMCP-Chain
 
 go 1.22.0
 
-require github.com/go-sql-driver/mysql v1.9.3
+require (
+    github.com/ethereum/go-ethereum v1.13.14
+    github.com/go-sql-driver/mysql v1.9.3
+    gopkg.in/yaml.v3 v3.0.1
+)
 
 require filippo.io/edwards25519 v1.1.0 // indirect

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -10,7 +10,7 @@ import (
 	"OpenMCP-Chain/internal/knowledge"
 	"OpenMCP-Chain/internal/llm"
 	"OpenMCP-Chain/internal/storage/mysql"
-	"OpenMCP-Chain/internal/web3/ethereum"
+	"OpenMCP-Chain/internal/web3"
 )
 
 // TaskRequest 描述了一个简单的智能体任务。
@@ -36,7 +36,7 @@ type TaskResult struct {
 // Agent 协调大模型与区块链交互，是系统的业务核心。
 type Agent struct {
 	llmClient   llm.Client
-	web3Client  *ethereum.Client
+	web3Client  web3.Client
 	taskStorage mysql.TaskRepository
 	memoryDepth int
 	knowledge   knowledge.Provider
@@ -74,7 +74,7 @@ func WithLLMTimeout(timeout time.Duration) Option {
 }
 
 // New 创建一个 Agent。
-func New(llmClient llm.Client, web3Client *ethereum.Client, repo mysql.TaskRepository, opts ...Option) *Agent {
+func New(llmClient llm.Client, web3Client web3.Client, repo mysql.TaskRepository, opts ...Option) *Agent {
 	ag := &Agent{
 		llmClient:   llmClient,
 		web3Client:  web3Client,
@@ -127,7 +127,7 @@ func (a *Agent) Execute(ctx context.Context, req TaskRequest) (*TaskResult, erro
 		return nil, fmt.Errorf("大模型推理失败: %w", err)
 	}
 
-	chainInfo := ethereum.ChainSnapshot{}
+	chainInfo := web3.ChainSnapshot{}
 	observations := appendObservation(historyObservation, knowledgeObservation)
 	if a.web3Client == nil {
 		observations = "未配置 Web3 客户端"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,7 +72,9 @@ func (c OpenAIConfig) Timeout() time.Duration {
 
 // Web3Config 包含访问区块链节点所需的 RPC 地址。
 type Web3Config struct {
-	RPCURL string `json:"rpc_url"`
+	RPCURL       string `json:"rpc_url"`
+	ChainConfig  string `json:"chain_config"`
+	DefaultChain string `json:"default_chain"`
 }
 
 // RuntimeConfig 用于放置运行时的通用参数。
@@ -167,5 +169,9 @@ func (c *Config) applyDefaults(baseDir string) {
 	}
 	if c.Knowledge.Source != "" && !filepath.IsAbs(c.Knowledge.Source) {
 		c.Knowledge.Source = filepath.Join(baseDir, c.Knowledge.Source)
+	}
+
+	if c.Web3.ChainConfig != "" && !filepath.IsAbs(c.Web3.ChainConfig) {
+		c.Web3.ChainConfig = filepath.Join(baseDir, c.Web3.ChainConfig)
 	}
 }

--- a/internal/web3/config.go
+++ b/internal/web3/config.go
@@ -1,0 +1,44 @@
+package web3
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ChainDefinitions models the structure of configs/chain.yaml.
+type ChainDefinitions struct {
+	Chains map[string]ChainDefinition `yaml:"chains"`
+}
+
+// ChainDefinition describes a single chain endpoint definition.
+type ChainDefinition struct {
+	Type        string `yaml:"type"`
+	RPCURL      string `yaml:"rpc_url"`
+	WSURL       string `yaml:"ws_url"`
+	BatchRPCURL string `yaml:"batch_rpc_url"`
+	Description string `yaml:"description"`
+}
+
+// LoadChainDefinitions parses the YAML file containing chain metadata.
+func LoadChainDefinitions(path string) (ChainDefinitions, error) {
+	if strings.TrimSpace(path) == "" {
+		return ChainDefinitions{Chains: map[string]ChainDefinition{}}, nil
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return ChainDefinitions{}, fmt.Errorf("读取链配置失败: %w", err)
+	}
+
+	var defs ChainDefinitions
+	if err := yaml.Unmarshal(content, &defs); err != nil {
+		return ChainDefinitions{}, fmt.Errorf("解析链配置失败: %w", err)
+	}
+	if defs.Chains == nil {
+		defs.Chains = map[string]ChainDefinition{}
+	}
+	return defs, nil
+}

--- a/internal/web3/doc.go
+++ b/internal/web3/doc.go
@@ -1,4 +1,7 @@
 // Package web3 houses blockchain connectivity utilities, including signer
-// abstractions, RPC clients, and smart contract bindings. It enables agents to
-// perform standardized interactions with supported networks.
+// abstractions, RPC clients, smart contract bindings, and multi-chain
+// configuration helpers. It enables agents to perform standardized
+// interactions with supported networks such as Ethereum, BSC, and Polygon,
+// supporting advanced operations like contract deployment, event
+// subscriptions, and batched transactions.
 package web3

--- a/internal/web3/ethereum/client.go
+++ b/internal/web3/ethereum/client.go
@@ -1,66 +1,181 @@
 package ethereum
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
+	"encoding/hex"
 	"errors"
 	"fmt"
-	"net/http"
+	"math/big"
 	"strings"
-	"time"
+	"sync"
+
+	"OpenMCP-Chain/internal/web3"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
+	"github.com/ethereum/go-ethereum/common"
+	coretypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	gethcore "github.com/ethereum/go-ethereum/ethereum"
+	gethevent "github.com/ethereum/go-ethereum/event"
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
 )
 
-// Client 通过 JSON-RPC 与以太坊兼容链交互。
-type Client struct {
-	rpcURL     string
-	httpClient *http.Client
-}
-
-// ChainSnapshot 表示一次对链上状态的快速查询结果。
-type ChainSnapshot struct {
-	ChainID     string
-	BlockNumber string
+// Config describes how to construct an EVM compatible client.
+type Config struct {
+	Name        string
+	RPCURL      string
+	WSURL       string
+	BatchRPCURL string
 	Notes       string
 }
 
-// NewClient 创建一个新的以太坊 RPC 客户端。
-func NewClient(rpcURL string) *Client {
-	return &Client{
-		rpcURL: rpcURL,
-		httpClient: &http.Client{
-			Timeout: 10 * time.Second,
-		},
-	}
+// Client implements the web3.Client interface for EVM compatible chains.
+type Client struct {
+	name        string
+	notes       string
+	rpcClient   *gethrpc.Client
+	batchClient *gethrpc.Client
+	eth         *ethclient.Client
+	eventClient logSubscriber
+	backend     bind.ContractBackend
+	chainID     *big.Int
+	mu          sync.Mutex
 }
 
-// FetchChainSnapshot 获取链 ID 和最新区块高度。
-func (c *Client) FetchChainSnapshot(ctx context.Context) (ChainSnapshot, error) {
-	if c == nil {
-		return ChainSnapshot{}, errors.New("未初始化的以太坊客户端")
-	}
-	if strings.TrimSpace(c.rpcURL) == "" {
-		return ChainSnapshot{}, errors.New("未配置以太坊 RPC 地址")
+// logSubscriber mirrors the subset of methods required for log subscriptions.
+type logSubscriber interface {
+	SubscribeFilterLogs(ctx context.Context, q gethcore.FilterQuery, ch chan<- coretypes.Log) (gethevent.Subscription, error)
+}
+
+// NewClient dials the configured RPC endpoints and returns a ready-to-use client.
+func NewClient(ctx context.Context, cfg Config) (*Client, error) {
+	rpcURL := strings.TrimSpace(cfg.RPCURL)
+	if rpcURL == "" {
+		return nil, errors.New("未配置以太坊 RPC 地址")
 	}
 
-	chainID, err := c.callStringResult(ctx, "eth_chainId", nil)
+	rpcClient, err := gethrpc.DialContext(ctx, rpcURL)
 	if err != nil {
-		return ChainSnapshot{}, err
+		return nil, fmt.Errorf("连接以太坊节点失败: %w", err)
 	}
 
-	blockNumber, err := c.callStringResult(ctx, "eth_blockNumber", nil)
-	if err != nil {
-		return ChainSnapshot{}, err
+	eth := ethclient.NewClient(rpcClient)
+
+	batchClient := rpcClient
+	if batchURL := strings.TrimSpace(cfg.BatchRPCURL); batchURL != "" && batchURL != rpcURL {
+		batchClient, err = gethrpc.DialContext(ctx, batchURL)
+		if err != nil {
+			return nil, fmt.Errorf("连接批量交易节点失败: %w", err)
+		}
 	}
 
-	return ChainSnapshot{
-		ChainID:     chainID,
-		BlockNumber: blockNumber,
-		Notes:       "",
+	eventClient := logSubscriber(eth)
+	if wsURL := strings.TrimSpace(cfg.WSURL); wsURL != "" {
+		if wsRPC, wsErr := gethrpc.DialContext(ctx, wsURL); wsErr == nil {
+			eventClient = ethclient.NewClient(wsRPC)
+		}
+	}
+
+	return &Client{
+		name:        cfg.Name,
+		notes:       cfg.Notes,
+		rpcClient:   rpcClient,
+		batchClient: batchClient,
+		eth:         eth,
+		eventClient: eventClient,
+		backend:     eth,
 	}, nil
 }
 
-// ExecuteAction 根据预定义模板执行常见的 JSON-RPC 方法。
+// NewSimulatedClient wraps a go-ethereum simulated backend for testing purposes.
+func NewSimulatedClient(name string, chainID *big.Int, backend *backends.SimulatedBackend) *Client {
+	return &Client{
+		name:        name,
+		backend:     backend,
+		eventClient: backend,
+		chainID:     new(big.Int).Set(chainID),
+		notes:       "simulated backend",
+	}
+}
+
+// Close releases network connections held by the client.
+func (c *Client) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.eth != nil {
+		c.eth.Close()
+		c.eth = nil
+	}
+	if c.eventClient != nil {
+		if ec, ok := c.eventClient.(*ethclient.Client); ok {
+			ec.Close()
+		}
+		c.eventClient = nil
+	}
+	if c.batchClient != nil && c.batchClient != c.rpcClient {
+		c.batchClient.Close()
+	}
+	if c.rpcClient != nil {
+		c.rpcClient.Close()
+	}
+	c.rpcClient = nil
+	c.batchClient = nil
+}
+
+// FetchChainSnapshot gathers lightweight metadata from the chain.
+func (c *Client) FetchChainSnapshot(ctx context.Context) (web3.ChainSnapshot, error) {
+	if c == nil {
+		return web3.ChainSnapshot{}, errors.New("未初始化的以太坊客户端")
+	}
+
+	if c.eth != nil {
+		chainID, err := c.eth.ChainID(ctx)
+		if err != nil {
+			return web3.ChainSnapshot{}, fmt.Errorf("获取链 ID 失败: %w", err)
+		}
+		blockNumber, err := c.eth.BlockNumber(ctx)
+		if err != nil {
+			return web3.ChainSnapshot{}, fmt.Errorf("获取最新区块高度失败: %w", err)
+		}
+		return web3.ChainSnapshot{
+			ChainID:     toHexBig(chainID),
+			BlockNumber: fmt.Sprintf("0x%x", blockNumber),
+			Notes:       c.notes,
+		}, nil
+	}
+
+	backend := c.backend
+	if backend == nil {
+		return web3.ChainSnapshot{}, errors.New("客户端缺少链访问后端")
+	}
+
+	id := c.chainID
+	if id == nil {
+		return web3.ChainSnapshot{}, errors.New("未配置链 ID")
+	}
+
+	blockReader, ok := backend.(interface {
+		BlockByNumber(context.Context, *big.Int) (*coretypes.Block, error)
+	})
+	if !ok {
+		return web3.ChainSnapshot{}, errors.New("后端不支持区块查询")
+	}
+	block, err := blockReader.BlockByNumber(ctx, nil)
+	if err != nil {
+		return web3.ChainSnapshot{}, fmt.Errorf("获取区块信息失败: %w", err)
+	}
+
+	return web3.ChainSnapshot{
+		ChainID:     toHexBig(id),
+		BlockNumber: fmt.Sprintf("0x%x", block.NumberU64()),
+		Notes:       c.notes,
+	}, nil
+}
+
+// ExecuteAction runs small helper RPC calls for the agent layer.
 func (c *Client) ExecuteAction(ctx context.Context, action, address string) (string, error) {
 	if c == nil {
 		return "", errors.New("未初始化的以太坊客户端")
@@ -69,9 +184,6 @@ func (c *Client) ExecuteAction(ctx context.Context, action, address string) (str
 	if action == "" {
 		return "", errors.New("链上操作不能为空")
 	}
-	if strings.TrimSpace(c.rpcURL) == "" {
-		return "", errors.New("未配置以太坊 RPC 地址")
-	}
 
 	switch action {
 	case "eth_getBalance":
@@ -79,92 +191,187 @@ func (c *Client) ExecuteAction(ctx context.Context, action, address string) (str
 		if addr == "" {
 			return "", errors.New("eth_getBalance 需要提供地址")
 		}
-		return c.callStringResult(ctx, action, []any{addr, "latest"})
+		backend := c.balanceBackend()
+		if backend == nil {
+			return "", errors.New("当前客户端不支持余额查询")
+		}
+		balance, err := backend.BalanceAt(ctx, common.HexToAddress(addr), nil)
+		if err != nil {
+			return "", fmt.Errorf("查询余额失败: %w", err)
+		}
+		return toHexBig(balance), nil
 	case "eth_getTransactionCount":
 		addr := strings.TrimSpace(address)
 		if addr == "" {
 			return "", errors.New("eth_getTransactionCount 需要提供地址")
 		}
-		return c.callStringResult(ctx, action, []any{addr, "latest"})
+		backend := c.nonceBackend()
+		if backend == nil {
+			return "", errors.New("当前客户端不支持交易计数查询")
+		}
+		nonce, err := backend.PendingNonceAt(ctx, common.HexToAddress(addr))
+		if err != nil {
+			return "", fmt.Errorf("查询交易计数失败: %w", err)
+		}
+		return fmt.Sprintf("0x%x", nonce), nil
 	default:
 		return "", fmt.Errorf("暂不支持的链上操作: %s", action)
 	}
 }
 
-// callStringResult 发起 JSON-RPC 调用并返回字符串结果。
-func (c *Client) callStringResult(ctx context.Context, method string, params any) (string, error) {
-	var paramSlice []any
-	if params != nil {
-		if arr, ok := params.([]any); ok {
-			paramSlice = arr
-		} else {
-			paramSlice = []any{params}
+// DeployContract sends the contract creation transaction using the provided
+// transact opts and bytecode.
+func (c *Client) DeployContract(ctx context.Context, auth *bind.TransactOpts, abiJSON string, bytecode []byte, params ...any) (web3.DeploymentResult, error) {
+	if auth == nil {
+		return web3.DeploymentResult{}, errors.New("未提供交易签名器")
+	}
+	backend := c.contractBackend()
+	if backend == nil {
+		return web3.DeploymentResult{}, errors.New("当前客户端不支持合约部署")
+	}
+	if len(bytecode) == 0 {
+		return web3.DeploymentResult{}, errors.New("合约字节码不能为空")
+	}
+
+	parsedABI, err := abi.JSON(strings.NewReader(abiJSON))
+	if err != nil {
+		return web3.DeploymentResult{}, fmt.Errorf("解析 ABI 失败: %w", err)
+	}
+
+	originalCtx := auth.Context
+	auth.Context = ctx
+	defer func() { auth.Context = originalCtx }()
+
+	address, tx, _, err := bind.DeployContract(auth, parsedABI, bytecode, backend, params...)
+	if err != nil {
+		return web3.DeploymentResult{}, fmt.Errorf("部署合约失败: %w", err)
+	}
+
+	if sim, ok := backend.(*backends.SimulatedBackend); ok {
+		sim.Commit()
+	}
+
+	return web3.DeploymentResult{ContractAddress: address, Transaction: tx}, nil
+}
+
+// SubscribeEvents attaches a log subscription to the chain.
+func (c *Client) SubscribeEvents(ctx context.Context, query gethcore.FilterQuery) (*web3.EventSubscription, error) {
+	if c == nil {
+		return nil, errors.New("未初始化的以太坊客户端")
+	}
+	subscriber := c.eventBackend()
+	if subscriber == nil {
+		return nil, errors.New("当前客户端不支持事件订阅")
+	}
+
+	logs := make(chan coretypes.Log, 64)
+	sub, err := subscriber.SubscribeFilterLogs(ctx, query, logs)
+	if err != nil {
+		return nil, fmt.Errorf("订阅事件失败: %w", err)
+	}
+	return web3.NewEventSubscription(logs, sub), nil
+}
+
+// SendBatchTransactions broadcasts multiple signed transactions in a single
+// RPC batch call when possible.
+func (c *Client) SendBatchTransactions(ctx context.Context, txs []*coretypes.Transaction) ([]common.Hash, error) {
+	if len(txs) == 0 {
+		return nil, errors.New("没有可发送的交易")
+	}
+
+	if backend, ok := c.backend.(*backends.SimulatedBackend); ok && c.rpcClient == nil {
+		hashes := make([]common.Hash, 0, len(txs))
+		for _, tx := range txs {
+			if err := backend.SendTransaction(ctx, tx); err != nil {
+				return nil, fmt.Errorf("发送交易失败: %w", err)
+			}
+			backend.Commit()
+			hashes = append(hashes, tx.Hash())
+		}
+		return hashes, nil
+	}
+
+	if c.batchClient == nil {
+		return nil, errors.New("当前客户端未配置批量 RPC")
+	}
+
+	hashes := make([]common.Hash, len(txs))
+	elems := make([]gethrpc.BatchElem, len(txs))
+	for i, tx := range txs {
+		raw, err := tx.MarshalBinary()
+		if err != nil {
+			return nil, fmt.Errorf("序列化交易失败: %w", err)
+		}
+		hexPayload := "0x" + hex.EncodeToString(raw)
+		elems[i] = gethrpc.BatchElem{
+			Method: "eth_sendRawTransaction",
+			Args:   []any{hexPayload},
+			Result: &hashes[i],
 		}
 	}
 
-	payload := rpcRequest{
-		JSONRPC: "2.0",
-		Method:  method,
-		Params:  paramSlice,
-		ID:      1,
+	if err := c.batchClient.BatchCallContext(ctx, elems); err != nil {
+		return nil, fmt.Errorf("批量发送交易失败: %w", err)
 	}
-
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return "", fmt.Errorf("序列化 JSON-RPC 请求失败: %w", err)
+	for i := range elems {
+		if elems[i].Error != nil {
+			return nil, fmt.Errorf("交易 %d 发送失败: %w", i, elems[i].Error)
+		}
 	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.rpcURL, bytes.NewReader(body))
-	if err != nil {
-		return "", fmt.Errorf("构造 HTTP 请求失败: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("调用链上节点失败: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("节点返回异常状态码: %s", resp.Status)
-	}
-
-	var rpcResp rpcResponse
-	if err := json.NewDecoder(resp.Body).Decode(&rpcResp); err != nil {
-		return "", fmt.Errorf("解析 JSON-RPC 响应失败: %w", err)
-	}
-
-	if rpcResp.Error != nil {
-		return "", fmt.Errorf("链上返回错误: %s", rpcResp.Error.Message)
-	}
-
-	var result string
-	if err := json.Unmarshal(rpcResp.Result, &result); err != nil {
-		return "", fmt.Errorf("解析 JSON-RPC 结果失败: %w", err)
-	}
-
-	return result, nil
+	return hashes, nil
 }
 
-// rpcRequest 定义了 JSON-RPC 请求的结构。
-type rpcRequest struct {
-	JSONRPC string `json:"jsonrpc"`
-	Method  string `json:"method"`
-	Params  []any  `json:"params"`
-	ID      int    `json:"id"`
+func (c *Client) contractBackend() bind.ContractBackend {
+	if c.backend != nil {
+		return c.backend
+	}
+	if c.eth != nil {
+		return c.eth
+	}
+	return nil
 }
 
-// rpcResponse 定义了 JSON-RPC 响应的结构。
-type rpcResponse struct {
-	JSONRPC string          `json:"jsonrpc"`
-	Result  json.RawMessage `json:"result"`
-	Error   *rpcError       `json:"error"`
-	ID      int             `json:"id"`
+func (c *Client) eventBackend() logSubscriber {
+	if c.eventClient != nil {
+		return c.eventClient
+	}
+	if subscriber, ok := c.backend.(logSubscriber); ok {
+		return subscriber
+	}
+	return nil
 }
 
-// rpcError 定义了 JSON-RPC 错误的结构。
-type rpcError struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
+func (c *Client) balanceBackend() interface {
+	BalanceAt(context.Context, common.Address, *big.Int) (*big.Int, error)
+} {
+	if backend, ok := c.backend.(interface {
+		BalanceAt(context.Context, common.Address, *big.Int) (*big.Int, error)
+	}); ok {
+		return backend
+	}
+	if c.eth != nil {
+		return c.eth
+	}
+	return nil
+}
+
+func (c *Client) nonceBackend() interface {
+	PendingNonceAt(context.Context, common.Address) (uint64, error)
+} {
+	if backend, ok := c.backend.(interface {
+		PendingNonceAt(context.Context, common.Address) (uint64, error)
+	}); ok {
+		return backend
+	}
+	if c.eth != nil {
+		return c.eth
+	}
+	return nil
+}
+
+func toHexBig(n *big.Int) string {
+	if n == nil {
+		return "0x0"
+	}
+	return "0x" + n.Text(16)
 }

--- a/internal/web3/ethereum/client_test.go
+++ b/internal/web3/ethereum/client_test.go
@@ -1,0 +1,114 @@
+package ethereum
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"OpenMCP-Chain/internal/web3"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	coretypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	gethcore "github.com/ethereum/go-ethereum/ethereum"
+)
+
+const (
+	simpleContractABI = "[]"
+	simpleContractBin = "0x6006600c60003960066000f360006000a000"
+)
+
+func TestClientDeploySubscribeBatch(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	chainID := big.NewInt(1337)
+	auth, err := bind.NewKeyedTransactorWithChainID(key, chainID)
+	if err != nil {
+		t.Fatalf("new transactor: %v", err)
+	}
+	auth.GasLimit = 1_000_000
+
+	alloc := core.GenesisAlloc{
+		auth.From: {Balance: big.NewInt(1_000_000_000_000_000_000)},
+	}
+	backend := backends.NewSimulatedBackend(alloc, 8_000_000)
+	client := NewSimulatedClient("simulated", chainID, backend)
+	t.Cleanup(client.Close)
+
+	bytecode := common.FromHex(simpleContractBin)
+	deployResult, err := client.DeployContract(ctx, auth, simpleContractABI, bytecode)
+	if err != nil {
+		t.Fatalf("deploy contract: %v", err)
+	}
+	if deployResult.ContractAddress == (common.Address{}) {
+		t.Fatal("expected contract address to be non-zero")
+	}
+
+	snapshot, err := client.FetchChainSnapshot(ctx)
+	if err != nil {
+		t.Fatalf("fetch snapshot: %v", err)
+	}
+	if snapshot.ChainID != "0x"+chainID.Text(16) {
+		t.Fatalf("unexpected chain id %s", snapshot.ChainID)
+	}
+	if snapshot.BlockNumber == "0x0" {
+		t.Fatal("expected block number to advance after deployment")
+	}
+
+	logQuery := gethcore.FilterQuery{Addresses: []common.Address{deployResult.ContractAddress}}
+	sub, err := client.SubscribeEvents(ctx, logQuery)
+	if err != nil {
+		t.Fatalf("subscribe events: %v", err)
+	}
+	defer sub.Close()
+
+	nonce, err := backend.PendingNonceAt(ctx, auth.From)
+	if err != nil {
+		t.Fatalf("pending nonce: %v", err)
+	}
+	tx := coretypes.NewTransaction(nonce, deployResult.ContractAddress, big.NewInt(0), 120000, big.NewInt(1), nil)
+	signed, err := coretypes.SignTx(tx, coretypes.LatestSignerForChainID(chainID), key)
+	if err != nil {
+		t.Fatalf("sign tx: %v", err)
+	}
+
+	hashes, err := client.SendBatchTransactions(ctx, []*coretypes.Transaction{signed})
+	if err != nil {
+		t.Fatalf("send batch: %v", err)
+	}
+	if len(hashes) != 1 {
+		t.Fatalf("expected 1 hash, got %d", len(hashes))
+	}
+
+	logCh := sub.Logs()
+	select {
+	case log := <-logCh:
+		if log.Address != deployResult.ContractAddress {
+			t.Fatalf("unexpected log address %s", log.Address.Hex())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for event log")
+	}
+
+	balanceHex, err := client.ExecuteAction(ctx, "eth_getBalance", auth.From.Hex())
+	if err != nil {
+		t.Fatalf("execute action: %v", err)
+	}
+	if balanceHex == "" {
+		t.Fatal("expected balance result")
+	}
+}
+
+var _ web3.Client = (*Client)(nil)

--- a/internal/web3/provider/registry.go
+++ b/internal/web3/provider/registry.go
@@ -1,0 +1,128 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"OpenMCP-Chain/internal/config"
+	"OpenMCP-Chain/internal/web3"
+	"OpenMCP-Chain/internal/web3/ethereum"
+)
+
+// Registry manages a set of chain clients keyed by human readable names.
+type Registry struct {
+	defaultChain string
+	clients      map[string]web3.Client
+}
+
+// NewRegistry loads chain definitions and instantiates concrete clients.
+func NewRegistry(ctx context.Context, cfg config.Web3Config) (*Registry, error) {
+	defs, err := web3.LoadChainDefinitions(cfg.ChainConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	clients := make(map[string]web3.Client)
+	for name, chain := range defs.Chains {
+		chainType := strings.ToLower(strings.TrimSpace(chain.Type))
+		if chainType == "" {
+			chainType = "evm"
+		}
+		switch chainType {
+		case "evm":
+			client, err := ethereum.NewClient(ctx, ethereum.Config{
+				Name:        name,
+				RPCURL:      chain.RPCURL,
+				WSURL:       chain.WSURL,
+				BatchRPCURL: chain.BatchRPCURL,
+				Notes:       chain.Description,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("初始化链 %s 失败: %w", name, err)
+			}
+			clients[name] = client
+		default:
+			return nil, fmt.Errorf("链 %s 使用了不支持的类型 %s", name, chain.Type)
+		}
+	}
+
+	if len(clients) == 0 && strings.TrimSpace(cfg.RPCURL) != "" {
+		client, err := ethereum.NewClient(ctx, ethereum.Config{RPCURL: cfg.RPCURL})
+		if err != nil {
+			return nil, err
+		}
+		clients["default"] = client
+		if cfg.DefaultChain == "" {
+			cfg.DefaultChain = "default"
+		}
+	}
+
+	if len(clients) == 0 {
+		return nil, errors.New("未配置任何链的 RPC 端点")
+	}
+
+	defaultChain := cfg.DefaultChain
+	if defaultChain == "" {
+		names := make([]string, 0, len(clients))
+		for name := range clients {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		defaultChain = names[0]
+	}
+	if _, ok := clients[defaultChain]; !ok {
+		return nil, fmt.Errorf("默认链 %s 未在配置中找到", defaultChain)
+	}
+
+	return &Registry{defaultChain: defaultChain, clients: clients}, nil
+}
+
+// DefaultClient returns the client configured as default chain.
+func (r *Registry) DefaultClient() (web3.Client, error) {
+	if r == nil {
+		return nil, errors.New("未初始化的链客户端注册表")
+	}
+	client, ok := r.clients[r.defaultChain]
+	if !ok {
+		return nil, fmt.Errorf("默认链 %s 未在注册表中", r.defaultChain)
+	}
+	return client, nil
+}
+
+// Client returns the chain client identified by name.
+func (r *Registry) Client(name string) (web3.Client, bool) {
+	if r == nil {
+		return nil, false
+	}
+	client, ok := r.clients[name]
+	return client, ok
+}
+
+// Close releases all clients managed by the registry.
+func (r *Registry) Close() {
+	if r == nil {
+		return
+	}
+	for name, client := range r.clients {
+		if client != nil {
+			client.Close()
+		}
+		delete(r.clients, name)
+	}
+}
+
+// Chains returns the list of registered chain names.
+func (r *Registry) Chains() []string {
+	if r == nil {
+		return nil
+	}
+	names := make([]string, 0, len(r.clients))
+	for name := range r.clients {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/web3/types.go
+++ b/internal/web3/types.go
@@ -1,0 +1,68 @@
+package web3
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	gethcore "github.com/ethereum/go-ethereum/ethereum"
+	gethevent "github.com/ethereum/go-ethereum/event"
+)
+
+// ChainSnapshot represents summarized network metadata for UI/reporting.
+type ChainSnapshot struct {
+	ChainID     string
+	BlockNumber string
+	Notes       string
+}
+
+// DeploymentResult captures the outcome of a contract deployment request.
+type DeploymentResult struct {
+	ContractAddress common.Address
+	Transaction     *types.Transaction
+}
+
+// EventSubscription wraps a log subscription so callers can manage lifecycle
+// without depending on the go-ethereum event package.
+type EventSubscription struct {
+	logs <-chan types.Log
+	sub  gethevent.Subscription
+}
+
+// NewEventSubscription constructs a managed subscription wrapper.
+func NewEventSubscription(logs <-chan types.Log, sub gethevent.Subscription) *EventSubscription {
+	return &EventSubscription{logs: logs, sub: sub}
+}
+
+// Logs returns the channel that receives blockchain logs.
+func (e *EventSubscription) Logs() <-chan types.Log {
+	return e.logs
+}
+
+// Err forwards the subscription error channel.
+func (e *EventSubscription) Err() <-chan error {
+	if e == nil || e.sub == nil {
+		return nil
+	}
+	return e.sub.Err()
+}
+
+// Close terminates the subscription.
+func (e *EventSubscription) Close() {
+	if e == nil || e.sub == nil {
+		return
+	}
+	e.sub.Unsubscribe()
+}
+
+// Client defines the common interface that any chain implementation must
+// provide so higher layers can interact with different networks uniformly.
+type Client interface {
+	FetchChainSnapshot(ctx context.Context) (ChainSnapshot, error)
+	ExecuteAction(ctx context.Context, action, address string) (string, error)
+	DeployContract(ctx context.Context, auth *bind.TransactOpts, abiJSON string, bytecode []byte, params ...any) (DeploymentResult, error)
+	SubscribeEvents(ctx context.Context, query gethcore.FilterQuery) (*EventSubscription, error)
+	SendBatchTransactions(ctx context.Context, txs []*types.Transaction) ([]common.Hash, error)
+	Close()
+}


### PR DESCRIPTION
## Summary
- replace the lightweight JSON-RPC stub with a go-ethereum based client that adds contract deployment, event subscriptions, and batched transactions
- introduce shared web3 interfaces, chain configuration loading, and a registry that instantiates clients for multiple chains
- extend the agent and daemon wiring plus default configs to consume the new interfaces and ship a YAML catalog of common EVM networks
- add an end-to-end test using a simulated backend to exercise deployment, subscription, and batch send helpers

## Testing
- go test ./... *(fails: missing go.sum entries because go-ethereum dependencies cannot be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68f2fbb9652c832f8ac53eebec3a1389